### PR TITLE
fix: added support for building 3.10 and 3.11

### DIFF
--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -30,6 +30,7 @@ jobs:
             rust: stable
             target: x86_64-pc-windows-msvc
             maturin_asset: maturin-x86_64-pc-windows-msvc.zip
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -38,16 +39,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Available on PyPi - https://pypi.org/project/mft/.
 To install from PyPi - `pip install mft`
 
 ### Wheels
-Wheels are currently automatically built for python 3.6,3.7,3.8,3.9 for all 64-bit platforms (Windows, macOS, and `manylinux`).
+Wheels are currently automatically built for python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11 for all 64-bit platforms (Windows, macOS, and `manylinux`).
 
 ### Installation from sources
 Installation is possible for other platforms by installing from sources, this requires a rust compiler and `setuptools-rust`.


### PR DESCRIPTION
@omerbenamram 
This great library was not yet compatible with newer versions of python, so I am adding 3.10 and 3.11 to the github-workflow version list.
I verified with local nektos/act and they work fine.

Could you please confirm the changes?

#6 